### PR TITLE
using calldata to save gas

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  printWidth: 120,
+}

--- a/contracts/IW3RC3.sol
+++ b/contracts/IW3RC3.sol
@@ -21,17 +21,9 @@ interface IW3RC3 {
         bytes memory data
     ) external payable;
 
-    function readChunk(bytes memory name, uint256 chunkId)
-        external
-        view
-        returns (bytes memory, bool);
+    function readChunk(bytes memory name, uint256 chunkId) external view returns (bytes memory, bool);
 
-    function chunkSize(bytes memory name, uint256 chunkId)
-        external
-        view
-        returns (uint256, bool);
+    function chunkSize(bytes memory name, uint256 chunkId) external view returns (uint256, bool);
 
-    function removeChunk(bytes memory name, uint256 chunkId)
-        external
-        returns (bool);
+    function removeChunk(bytes memory name, uint256 chunkId) external returns (bool);
 }

--- a/contracts/Memory.sol
+++ b/contracts/Memory.sol
@@ -131,11 +131,7 @@ library Memory {
 
     // This function does the same as 'dataPtr(bytes memory)', but will also return the
     // length of the provided bytes array.
-    function fromBytes(bytes memory bts)
-        internal
-        pure
-        returns (uint256 addr, uint256 len)
-    {
+    function fromBytes(bytes memory bts) internal pure returns (uint256 addr, uint256 len) {
         len = bts.length;
         assembly {
             addr := add(
@@ -149,11 +145,7 @@ library Memory {
     // Creates a 'bytes memory' variable from the memory address 'addr', with the
     // length 'len'. The function will allocate new memory for the bytes array, and
     // the 'len bytes starting at 'addr' will be copied into that new memory.
-    function toBytes(uint256 addr, uint256 len)
-        internal
-        pure
-        returns (bytes memory bts)
-    {
+    function toBytes(uint256 addr, uint256 len) internal pure returns (bytes memory bts) {
         bts = new bytes(len);
         uint256 btsptr;
         assembly {

--- a/contracts/StorageHelper.sol
+++ b/contracts/StorageHelper.sol
@@ -18,30 +18,8 @@ library StorageHelper {
     uint256 internal constant FACTORY_ADDR_OFF0 = 305 + 32 + ADDR_OFF0;
     uint256 internal constant FACTORY_ADDR_OFF1 = 305 + 32 + ADDR_OFF1;
 
-    function putRaw(bytes memory data, uint256 value)
-        internal
-        returns (address)
-    {
-        // create the new contract code with the data
-        bytes memory bytecode = STORAGE_SLOT_CODE;
-        uint256 bytecodeLen = bytecode.length;
-        uint256 newSize = bytecode.length + data.length;
-        assembly {
-            // in-place resize of bytecode bytes
-            // note that this must be done when bytecode is the last allocated object by solidity.
-            mstore(bytecode, newSize)
-            // notify solidity about the memory size increase, must be 32-bytes aligned
-            mstore(
-                0x40,
-                add(bytecode, and(add(add(newSize, 0x20), 0x1f), not(0x1f)))
-            )
-        }
-        // append data to self-destruct byte code
-        Memory.copy(
-            Memory.dataPtr(data),
-            Memory.dataPtr(bytecode) + bytecodeLen,
-            data.length
-        );
+    function putRawFromCalldata(bytes calldata data, uint256 value) internal returns (address) {
+        bytes memory bytecode = bytes.concat(STORAGE_SLOT_CODE, data);
         {
             // revise the owner to the contract (so that it is destructable)
             uint256 off = ADDR_OFF0 + 0x20;
@@ -54,9 +32,37 @@ library StorageHelper {
             }
         }
 
-        StorageSlotFactoryFromInput c = new StorageSlotFactoryFromInput{
-            value: value
-        }(bytecode);
+        StorageSlotFactoryFromInput c = new StorageSlotFactoryFromInput{value: value}(bytecode);
+        return address(c);
+    }
+
+    function putRaw(bytes memory data, uint256 value) internal returns (address) {
+        // create the new contract code with the data
+        bytes memory bytecode = STORAGE_SLOT_CODE;
+        uint256 bytecodeLen = bytecode.length;
+        uint256 newSize = bytecode.length + data.length;
+        assembly {
+            // in-place resize of bytecode bytes
+            // note that this must be done when bytecode is the last allocated object by solidity.
+            mstore(bytecode, newSize)
+            // notify solidity about the memory size increase, must be 32-bytes aligned
+            mstore(0x40, add(bytecode, and(add(add(newSize, 0x20), 0x1f), not(0x1f))))
+        }
+        // append data to self-destruct byte code
+        Memory.copy(Memory.dataPtr(data), Memory.dataPtr(bytecode) + bytecodeLen, data.length);
+        {
+            // revise the owner to the contract (so that it is destructable)
+            uint256 off = ADDR_OFF0 + 0x20;
+            assembly {
+                mstore(add(bytecode, off), address())
+            }
+            off = ADDR_OFF1 + 0x20;
+            assembly {
+                mstore(add(bytecode, off), address())
+            }
+        }
+
+        StorageSlotFactoryFromInput c = new StorageSlotFactoryFromInput{value: value}(bytecode);
         return address(c);
     }
 
@@ -74,17 +80,10 @@ library StorageHelper {
             // note that this must be done when bytecode is the last allocated object by solidity.
             mstore(bytecode, newSize)
             // notify solidity about the memory size increase, must be 32-bytes aligned
-            mstore(
-                0x40,
-                add(bytecode, and(add(add(newSize, 0x20), 0x1f), not(0x1f)))
-            )
+            mstore(0x40, add(bytecode, and(add(add(newSize, 0x20), 0x1f), not(0x1f))))
         }
         // append data to self-destruct byte code
-        Memory.copy(
-            Memory.dataPtr(data),
-            Memory.dataPtr(bytecode) + bytecodeLen,
-            data.length
-        );
+        Memory.copy(Memory.dataPtr(data), Memory.dataPtr(bytecode) + bytecodeLen, data.length);
         {
             // revise the size of calldata
             uint256 calldataSize = STORAGE_SLOT_CODE.length + data.length;
@@ -154,11 +153,7 @@ library StorageHelper {
         return (data, true);
     }
 
-    function getRawAt(address addr, uint256 memoryPtr)
-        internal
-        view
-        returns (uint256, bool)
-    {
+    function getRawAt(address addr, uint256 memoryPtr) internal view returns (uint256, bool) {
         (uint256 dataSize, bool found) = sizeRaw(addr);
 
         if (!found) {

--- a/contracts/StorageManager.sol
+++ b/contracts/StorageManager.sol
@@ -41,9 +41,7 @@ contract StorageManager {
 
         if (data.length > SLOT_LIMIT) {
             // store in new contract
-            keyToMetadata[key] = StorageHelper
-                .putRaw(data, value)
-                .addrToBytes32();
+            keyToMetadata[key] = StorageHelper.putRaw(data, value).addrToBytes32();
         } else {
             // store in slot
             keyToMetadata[key] = SlotHelper.putRaw(keyToSlots[key], data);
@@ -64,9 +62,7 @@ contract StorageManager {
 
         if (data.length > SLOT_LIMIT) {
             // store in new contract
-            keyToMetadata[key] = StorageHelper
-                .putRaw2(key, data, value)
-                .addrToBytes32();
+            keyToMetadata[key] = StorageHelper.putRaw2(key, data, value).addrToBytes32();
         } else {
             // store in slot
             keyToMetadata[key] = SlotHelper.putRaw(keyToSlots[key], data);

--- a/contracts/W3RC3.sol
+++ b/contracts/W3RC3.sol
@@ -17,31 +17,17 @@ contract W3RC3 is IW3RC3, LargeStorageManager {
     }
 
     // Large storage methods
-    function write(bytes memory name, bytes memory data)
-        public
-        payable
-        override
-    {
+    function write(bytes memory name, bytes calldata data) public payable override {
         require(msg.sender == owner, "must from owner");
         // TODO: support multiple chunks
-        return _putChunk(keccak256(name), 0, data, msg.value);
+        return _putChunkFromCalldata(keccak256(name), 0, data, msg.value);
     }
 
-    function read(bytes memory name)
-        public
-        view
-        override
-        returns (bytes memory, bool)
-    {
+    function read(bytes memory name) public view override returns (bytes memory, bool) {
         return _get(keccak256(name));
     }
 
-    function size(bytes memory name)
-        public
-        view
-        override
-        returns (uint256, uint256)
-    {
+    function size(bytes memory name) public view override returns (uint256, uint256) {
         return _size(keccak256(name));
     }
 
@@ -50,12 +36,7 @@ contract W3RC3 is IW3RC3, LargeStorageManager {
         return _remove(keccak256(name));
     }
 
-    function countChunks(bytes memory name)
-        public
-        view
-        override
-        returns (uint256)
-    {
+    function countChunks(bytes memory name) public view override returns (uint256) {
         return _countChunks(keccak256(name));
     }
 
@@ -69,29 +50,15 @@ contract W3RC3 is IW3RC3, LargeStorageManager {
         return _putChunk(keccak256(name), chunkId, data, msg.value);
     }
 
-    function readChunk(bytes memory name, uint256 chunkId)
-        public
-        view
-        override
-        returns (bytes memory, bool)
-    {
+    function readChunk(bytes memory name, uint256 chunkId) public view override returns (bytes memory, bool) {
         return _getChunk(keccak256(name), chunkId);
     }
 
-    function chunkSize(bytes memory name, uint256 chunkId)
-        public
-        view
-        override
-        returns (uint256, bool)
-    {
+    function chunkSize(bytes memory name, uint256 chunkId) public view override returns (uint256, bool) {
         return _chunkSize(keccak256(name), chunkId);
     }
 
-    function removeChunk(bytes memory name, uint256 chunkId)
-        public
-        override
-        returns (bool)
-    {
+    function removeChunk(bytes memory name, uint256 chunkId) public override returns (bool) {
         require(msg.sender == owner, "must from owner");
         return _removeChunk(keccak256(name), chunkId);
     }

--- a/contracts/W3RC3.sol
+++ b/contracts/W3RC3.sol
@@ -44,10 +44,10 @@ contract W3RC3 is IW3RC3, LargeStorageManager {
     function writeChunk(
         bytes memory name,
         uint256 chunkId,
-        bytes memory data
+        bytes calldata data
     ) public payable override {
         require(msg.sender == owner, "must from owner");
-        return _putChunk(keccak256(name), chunkId, data, msg.value);
+        return _putChunkFromCalldata(keccak256(name), chunkId, data, msg.value);
     }
 
     function readChunk(bytes memory name, uint256 chunkId) public view override returns (bytes memory, bool) {

--- a/contracts/examples/FlatDirectoryTest.sol
+++ b/contracts/examples/FlatDirectoryTest.sol
@@ -7,10 +7,7 @@ import "./FlatDirectory.sol";
 contract FlatDirectoryTest is FlatDirectory {
     constructor(uint8 slotLimit) FlatDirectory(slotLimit) {}
 
-    function readNonView(bytes memory name)
-        public
-        returns (bytes memory, bool)
-    {
+    function readNonView(bytes memory name) public returns (bytes memory, bool) {
         return _get(keccak256(name));
     }
 

--- a/contracts/optimize/SlotHelper.sol
+++ b/contracts/optimize/SlotHelper.sol
@@ -6,10 +6,7 @@ library SlotHelper {
     uint256 internal constant LEN_OFFSET = 224;
     uint256 internal constant FIRST_SLOT_DATA_SIZE = 28;
 
-    function putRaw(
-        mapping(uint256 => bytes32) storage slots,
-        bytes memory datas
-    ) internal returns (bytes32 mdata) {
+    function putRaw(mapping(uint256 => bytes32) storage slots, bytes memory datas) internal returns (bytes32 mdata) {
         uint256 len = datas.length;
         mdata = encodeMetadata(datas);
         if (len > FIRST_SLOT_DATA_SIZE) {
@@ -18,11 +15,7 @@ library SlotHelper {
             assembly {
                 ptr := add(datas, add(0x20, FIRST_SLOT_DATA_SIZE))
             }
-            for (
-                uint256 i = 0;
-                i < (len - FIRST_SLOT_DATA_SIZE + 32 - 1) / 32;
-                i++
-            ) {
+            for (uint256 i = 0; i < (len - FIRST_SLOT_DATA_SIZE + 32 - 1) / 32; i++) {
                 assembly {
                     value := mload(ptr)
                 }
@@ -32,11 +25,7 @@ library SlotHelper {
         }
     }
 
-    function encodeMetadata(bytes memory data)
-        internal
-        pure
-        returns (bytes32 medata)
-    {
+    function encodeMetadata(bytes memory data) internal pure returns (bytes32 medata) {
         uint256 datLen = data.length;
         uint256 value;
         assembly {
@@ -49,20 +38,12 @@ library SlotHelper {
         medata = bytes32(value | datLen);
     }
 
-    function decodeMetadata(bytes32 mdata)
-        internal
-        pure
-        returns (uint256 len, bytes32 data)
-    {
+    function decodeMetadata(bytes32 mdata) internal pure returns (uint256 len, bytes32 data) {
         len = decodeLen(mdata);
         data = mdata << SLOTDATA_RIGHT_SHIFT;
     }
 
-    function decodeMetadataToData(bytes32 mdata)
-        internal
-        pure
-        returns (uint256 len, bytes memory data)
-    {
+    function decodeMetadataToData(bytes32 mdata) internal pure returns (uint256 len, bytes memory data) {
         len = decodeLen(mdata);
         mdata = mdata << SLOTDATA_RIGHT_SHIFT;
         data = new bytes(len);
@@ -85,11 +66,7 @@ library SlotHelper {
             assembly {
                 ptr := add(data, add(0x20, FIRST_SLOT_DATA_SIZE))
             }
-            for (
-                uint256 i = 0;
-                i < (datalen - FIRST_SLOT_DATA_SIZE + 32 - 1) / 32;
-                i++
-            ) {
+            for (uint256 i = 0; i < (datalen - FIRST_SLOT_DATA_SIZE + 32 - 1) / 32; i++) {
                 value = slots[i];
                 assembly {
                     mstore(ptr, value)
@@ -106,7 +83,7 @@ library SlotHelper {
     ) internal view returns (uint256 datalen, bool found) {
         bytes32 datapart;
         (datalen, datapart) = decodeMetadata(mdata);
-        
+
         // memoryPtr:memoryPtr+32 is allocated for the data
         uint256 dataPtr = memoryPtr;
         assembly {
@@ -120,11 +97,7 @@ library SlotHelper {
             assembly {
                 ptr := add(dataPtr, FIRST_SLOT_DATA_SIZE)
             }
-            for (
-                uint256 i = 0;
-                i < (datalen - FIRST_SLOT_DATA_SIZE + 32 - 1) / 32;
-                i++
-            ) {
+            for (uint256 i = 0; i < (datalen - FIRST_SLOT_DATA_SIZE + 32 - 1) / 32; i++) {
                 value = slots[i];
                 assembly {
                     mstore(ptr, value)

--- a/contracts/optimize/SlotHelperTest.sol
+++ b/contracts/optimize/SlotHelperTest.sol
@@ -20,19 +20,11 @@ contract SlotHelperTest {
         return SlotHelper.encodeMetadata(data);
     }
 
-    function decodeMetadata(bytes32 mdata)
-        public
-        pure
-        returns (uint256, bytes32)
-    {
+    function decodeMetadata(bytes32 mdata) public pure returns (uint256, bytes32) {
         return SlotHelper.decodeMetadata(mdata);
     }
 
-    function decodeMetadata1(bytes32 mdata)
-        public
-        pure
-        returns (uint256, bytes memory)
-    {
+    function decodeMetadata1(bytes32 mdata) public pure returns (uint256, bytes memory) {
         return SlotHelper.decodeMetadataToData(mdata);
     }
 


### PR DESCRIPTION
With no quad memory gas cost (which I will propose a W3IP), the pre- and post- gas costs are



Size (KB) | ChunNum | Gas cost | Diff
-- | -- | -- | --
24 | 1 | 5,724,606 |  
48 | 2 | 6,468,672 | 744,066
72 | 3 | 7,204,620 | 735,948
96 | 4 | 7,939,356 | 734,736
120 | 5 | 8,675,208 | 735,852
144 | 6 | 9,410,508 | 735,300



Size (KB) | ChunNum | Gas cost | Diff
-- | -- | -- | --
24 | 1 | 5,521,296 |  
48 | 2 | 6,043,500 | 522,204
72 | 3 | 6,566,712 | 523,212
96 | 4 | 7,088,712 | 522,000
120 | 5 | 7,611,828 | 523,116
144 | 6 | 8,134,392 | 522,564

More than 200K is saved per 24K bytes data stored.


